### PR TITLE
Removing -lm option from portsf makefile

### DIFF
--- a/portsf/Makefile
+++ b/portsf/Makefile
@@ -6,7 +6,7 @@
 #
 CC=gcc
 
-CFLAGS=-O2 -Wall -lm -Dunix  -I./.
+CFLAGS=-O2 -Wall -Dunix  -I./.
 
 PSFOBJS=	portsf.o ieee80.o
 


### PR DESCRIPTION
I think this should get rid of those warnings you were seeing from clang, @will-anderson. I added the `-lm` option to the portsf makefile when I was faultfinding with the WASDAAT makefile. Pretty sure it's not actually needed.

Travis seems to still build this without complaining, so I think we're all good. The only warnings I see now are about the coding in portsf itself, which I'm prepared to let slide.
